### PR TITLE
Enable passing of stateless components

### DIFF
--- a/src/only-if.js
+++ b/src/only-if.js
@@ -1,17 +1,22 @@
-import React, { Component } from 'react';
+import React from 'react';
+
+const getDisplayName = (Component) => (
+  Component.displayName || Component.name || 'Component'
+);
 
 const isStateless = (Target) => (
   !(Target.prototype && Target.prototype.isReactComponent)
 );
 
-const wrapStateless = (Stateless) => {
-  class WrapperComponent extends Component {
+const wrapStateless = (stateless) => {
+  class Wrapped extends React.Component {
     render() {
-      return React.createElement(Stateless, this.props);
+      return stateless(this.props, this.context);
     }
   }
-  WrapperComponent.contextTypes = Stateless.contextTypes;
-  return WrapperComponent;
+  Wrapped.contextTypes = stateless.contextTypes;
+  Wrapped.propTypes = stateless.propTypes;
+  return Wrapped;
 };
 
 export default (Target, condition, Placeholder) => {
@@ -24,5 +29,7 @@ export default (Target, condition, Placeholder) => {
       return Placeholder ? React.createElement(Placeholder) : null;
     }
   }
+  Enhanced.displayName = `OnlyIf(${getDisplayName(Target)})`;
+
   return Enhanced;
 };

--- a/src/only-if.js
+++ b/src/only-if.js
@@ -1,12 +1,26 @@
 import React from 'react';
 
 export default (Target, condition, Placeholder) => {
+  const renderedPlaceholder = Placeholder
+    ? React.createElement(Placeholder)
+    : null;
+
+  if (!Target.prototype.isReactComponent) {
+    const StatelessComponent = (props, context) => (
+      condition(props, context)
+        ? React.createElement(Target, props)
+        : renderedPlaceholder
+    );
+    StatelessComponent.contextTypes = Target.contextTypes;
+    return StatelessComponent;
+  }
+
   class Component extends Target {
     render() {
       if (condition(this.props, this.state, this.context)) {
         return super.render();
       }
-      return Placeholder ? React.createElement(Placeholder) : null;
+      return renderedPlaceholder;
     }
   }
   return Component;

--- a/src/only-if.js
+++ b/src/only-if.js
@@ -1,27 +1,28 @@
-import React from 'react';
+import React, { Component } from 'react';
+
+const isStateless = (Target) => (
+  !(Target.prototype && Target.prototype.isReactComponent)
+);
+
+const wrapStateless = (Stateless) => {
+  class WrapperComponent extends Component {
+    render() {
+      return React.createElement(Stateless, this.props);
+    }
+  }
+  WrapperComponent.contextTypes = Stateless.contextTypes;
+  return WrapperComponent;
+};
 
 export default (Target, condition, Placeholder) => {
-  const renderedPlaceholder = Placeholder
-    ? React.createElement(Placeholder)
-    : null;
-
-  if (!Target.prototype.isReactComponent) {
-    const StatelessComponent = (props, context) => (
-      condition(props, context)
-        ? React.createElement(Target, props)
-        : renderedPlaceholder
-    );
-    StatelessComponent.contextTypes = Target.contextTypes;
-    return StatelessComponent;
-  }
-
-  class Component extends Target {
+  const Super = isStateless(Target) ? wrapStateless(Target) : Target;
+  class Enhanced extends Super {
     render() {
       if (condition(this.props, this.state, this.context)) {
         return super.render();
       }
-      return renderedPlaceholder;
+      return Placeholder ? React.createElement(Placeholder) : null;
     }
   }
-  return Component;
+  return Enhanced;
 };

--- a/src/only-if.spec.js
+++ b/src/only-if.spec.js
@@ -1,10 +1,21 @@
+/* eslint react/no-multi-comp: 0 */
+
 import assert from 'assert';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
-import React from 'react';
+import React, { Component } from 'react';
 import onlyIf from './only-if';
 
-const Dummy = React.createClass({
+class ExtendsComponentDummy extends Component {
+  render() {
+    return <div>Dummy</div>;
+  }
+}
+ExtendsComponentDummy.contextTypes = {
+  test: React.PropTypes.bool,
+};
+
+const CreateClassDummy = React.createClass({
   contextTypes: {
     test: React.PropTypes.bool,
   },
@@ -22,53 +33,56 @@ StatelessDummy.contextTypes = {
 
 const Placeholder = () => <div>Placeholder</div>;
 
+const runTest = (Dummy, description) => {
+  describe(description, () => {
+    it('calls the condition function with the props', () => {
+      const callback = sinon.spy();
+      const props = { test: true };
+      const DummyOnlyIf = onlyIf(Dummy, callback);
+      shallow(<DummyOnlyIf {...props} />);
+      assert(callback.calledWith(props));
+    });
+
+    it('calls the condition function with the state', () => {
+      const callback = sinon.spy();
+      const state = { test: true };
+      const DummyOnlyIf = onlyIf(Dummy, callback);
+      const wrapper = shallow(<DummyOnlyIf />);
+      wrapper.setState(state);
+      assert(callback.calledWith({}, state));
+    });
+
+    it('calls the condition function with the context', () => {
+      const callback = sinon.spy();
+      const context = { test: true };
+      const DummyOnlyIf = onlyIf(Dummy, callback);
+      shallow(<DummyOnlyIf />, { context });
+      assert(callback.calledWith({}, null, context));
+    });
+
+    it('renders the component if the condition is true', () => {
+      const DummyOnlyIf = onlyIf(Dummy, () => true);
+      const wrapper = shallow(<DummyOnlyIf />);
+      assert(wrapper.containsMatchingElement(Dummy));
+    });
+
+    it('renders the placeholder if the condition is false', () => {
+      const DummyOnlyIf = onlyIf(Dummy, () => false, Placeholder);
+      const wrapper = shallow(<DummyOnlyIf />);
+      assert(wrapper.contains(<Placeholder />));
+    });
+
+    it('renders null if the placeholder does not exist', () => {
+      const DummyOnlyIf = onlyIf(Dummy, () => false);
+      const wrapper = shallow(<DummyOnlyIf />);
+      assert.equal(wrapper.type(), null);
+    });
+  });
+};
+
+
 describe('onlyIf', () => {
-  it('calls the condition function with the props', () => {
-    const callback = sinon.spy();
-    const props = { test: true };
-    const DummyOnlyIf = onlyIf(Dummy, callback);
-    shallow(<DummyOnlyIf {...props} />);
-    assert(callback.calledWith(props));
-  });
-
-  it('calls the condition function with the state', () => {
-    const callback = sinon.spy();
-    const state = { test: true };
-    const DummyOnlyIf = onlyIf(Dummy, callback);
-    const wrapper = shallow(<DummyOnlyIf />);
-    wrapper.setState(state);
-    assert(callback.calledWith({}, state));
-  });
-
-  it('calls the condition function with the context', () => {
-    const callback = sinon.spy();
-    const context = { test: true };
-    const DummyOnlyIf = onlyIf(Dummy, callback);
-    shallow(<DummyOnlyIf />, { context });
-    assert(callback.calledWith({}, null, context));
-  });
-
-  it('renders the component if the condition is true', () => {
-    const DummyOnlyIf = onlyIf(Dummy, () => true);
-    const wrapper = shallow(<DummyOnlyIf />);
-    assert(wrapper.containsMatchingElement(Dummy));
-  });
-
-  it('renders the placeholder if the condition is false', () => {
-    const DummyOnlyIf = onlyIf(Dummy, () => false, Placeholder);
-    const wrapper = shallow(<DummyOnlyIf />);
-    assert(wrapper.contains(<Placeholder />));
-  });
-
-  it('renders null if the placeholder does not exist', () => {
-    const DummyOnlyIf = onlyIf(Dummy, () => false);
-    const wrapper = shallow(<DummyOnlyIf />);
-    assert.equal(wrapper.type(), null);
-  });
-
-  it('wraps stateless components and renders them if the condition is true', () => {
-    const DummyOnlyIf = onlyIf(StatelessDummy, () => true);
-    const wrapper = shallow(<DummyOnlyIf />);
-    assert(wrapper.contains(<StatelessDummy />));
-  });
+  runTest(ExtendsComponentDummy, '`extends Component` component');
+  runTest(CreateClassDummy, '`createClass` component');
+  runTest(StatelessDummy, 'stateless component');
 });

--- a/src/only-if.spec.js
+++ b/src/only-if.spec.js
@@ -23,85 +23,52 @@ StatelessDummy.contextTypes = {
 const Placeholder = () => <div>Placeholder</div>;
 
 describe('onlyIf', () => {
-  context('stateful components', () => {
-    it('calls the condition function with the props', () => {
-      const callback = sinon.spy();
-      const props = { test: true };
-      const DummyOnlyIf = onlyIf(Dummy, callback);
-      shallow(<DummyOnlyIf {...props} />);
-      assert(callback.calledWith(props));
-    });
-
-    it('calls the condition function with the state', () => {
-      const callback = sinon.spy();
-      const state = { test: true };
-      const DummyOnlyIf = onlyIf(Dummy, callback);
-      const wrapper = shallow(<DummyOnlyIf />);
-      wrapper.setState(state);
-      assert(callback.calledWith({}, state));
-    });
-
-    it('calls the condition function with the context', () => {
-      const callback = sinon.spy();
-      const context = { test: true };
-      const DummyOnlyIf = onlyIf(Dummy, callback);
-      shallow(<DummyOnlyIf />, { context });
-      assert(callback.calledWith({}, null, context));
-    });
-
-    it('renders the component if the condition is true', () => {
-      const DummyOnlyIf = onlyIf(Dummy, () => true);
-      const wrapper = shallow(<DummyOnlyIf />);
-      assert(wrapper.containsMatchingElement(Dummy));
-    });
-
-    it('renders the placeholder if the condition is false', () => {
-      const DummyOnlyIf = onlyIf(Dummy, () => false, Placeholder);
-      const wrapper = shallow(<DummyOnlyIf />);
-      assert(wrapper.contains(<Placeholder />));
-    });
-
-    it('renders null if the placeholder does not exist', () => {
-      const DummyOnlyIf = onlyIf(Dummy, () => false);
-      const wrapper = shallow(<DummyOnlyIf />);
-      assert.equal(wrapper.type(), null);
-    });
+  it('calls the condition function with the props', () => {
+    const callback = sinon.spy();
+    const props = { test: true };
+    const DummyOnlyIf = onlyIf(Dummy, callback);
+    shallow(<DummyOnlyIf {...props} />);
+    assert(callback.calledWith(props));
   });
 
-  context('stateless components', () => {
-    it('calls the condition function with the props', () => {
-      const callback = sinon.spy();
-      const props = { test: true };
-      const DummyOnlyIf = onlyIf(StatelessDummy, callback);
-      shallow(<DummyOnlyIf {...props} />);
-      assert(callback.calledWith(props));
-    });
+  it('calls the condition function with the state', () => {
+    const callback = sinon.spy();
+    const state = { test: true };
+    const DummyOnlyIf = onlyIf(Dummy, callback);
+    const wrapper = shallow(<DummyOnlyIf />);
+    wrapper.setState(state);
+    assert(callback.calledWith({}, state));
+  });
 
-    it('calls the condition function with the context', () => {
-      const callback = sinon.spy();
-      const context = { test: true };
-      const DummyOnlyIf = onlyIf(StatelessDummy, callback);
-      shallow(<DummyOnlyIf />, { context });
-      assert(callback.calledOnce);
-      assert(callback.calledWith({}, context));
-    });
+  it('calls the condition function with the context', () => {
+    const callback = sinon.spy();
+    const context = { test: true };
+    const DummyOnlyIf = onlyIf(Dummy, callback);
+    shallow(<DummyOnlyIf />, { context });
+    assert(callback.calledWith({}, null, context));
+  });
 
-    it('renders the component if the condition is true', () => {
-      const DummyOnlyIf = onlyIf(StatelessDummy, () => true);
-      const wrapper = shallow(<DummyOnlyIf />);
-      assert(wrapper.contains(<StatelessDummy />));
-    });
+  it('renders the component if the condition is true', () => {
+    const DummyOnlyIf = onlyIf(Dummy, () => true);
+    const wrapper = shallow(<DummyOnlyIf />);
+    assert(wrapper.containsMatchingElement(Dummy));
+  });
 
-    it('renders the placeholder if the condition is false', () => {
-      const DummyOnlyIf = onlyIf(StatelessDummy, () => false, Placeholder);
-      const wrapper = shallow(<DummyOnlyIf />);
-      assert(wrapper.contains(<Placeholder />));
-    });
+  it('renders the placeholder if the condition is false', () => {
+    const DummyOnlyIf = onlyIf(Dummy, () => false, Placeholder);
+    const wrapper = shallow(<DummyOnlyIf />);
+    assert(wrapper.contains(<Placeholder />));
+  });
 
-    it('renders null if the placeholder does not exist', () => {
-      const DummyOnlyIf = onlyIf(StatelessDummy, () => false);
-      const wrapper = shallow(<DummyOnlyIf />);
-      assert.equal(wrapper.type(), null);
-    });
+  it('renders null if the placeholder does not exist', () => {
+    const DummyOnlyIf = onlyIf(Dummy, () => false);
+    const wrapper = shallow(<DummyOnlyIf />);
+    assert.equal(wrapper.type(), null);
+  });
+
+  it('wraps stateless components and renders them if the condition is true', () => {
+    const DummyOnlyIf = onlyIf(StatelessDummy, () => true);
+    const wrapper = shallow(<DummyOnlyIf />);
+    assert(wrapper.contains(<StatelessDummy />));
   });
 });

--- a/src/only-if.spec.js
+++ b/src/only-if.spec.js
@@ -13,49 +13,95 @@ const Dummy = React.createClass({
   },
 });
 
+const StatelessDummy = () => (
+  <div>Stateless Dummy</div>
+);
+StatelessDummy.contextTypes = {
+  test: React.PropTypes.bool,
+};
+
 const Placeholder = () => <div>Placeholder</div>;
 
 describe('onlyIf', () => {
-  it('calls the condition function with the props', () => {
-    const callback = sinon.spy();
-    const props = { test: true };
-    const DummyOnlyIf = onlyIf(Dummy, callback);
-    shallow(<DummyOnlyIf {...props} />);
-    assert(callback.calledWith(props));
+  context('stateful components', () => {
+    it('calls the condition function with the props', () => {
+      const callback = sinon.spy();
+      const props = { test: true };
+      const DummyOnlyIf = onlyIf(Dummy, callback);
+      shallow(<DummyOnlyIf {...props} />);
+      assert(callback.calledWith(props));
+    });
+
+    it('calls the condition function with the state', () => {
+      const callback = sinon.spy();
+      const state = { test: true };
+      const DummyOnlyIf = onlyIf(Dummy, callback);
+      const wrapper = shallow(<DummyOnlyIf />);
+      wrapper.setState(state);
+      assert(callback.calledWith({}, state));
+    });
+
+    it('calls the condition function with the context', () => {
+      const callback = sinon.spy();
+      const context = { test: true };
+      const DummyOnlyIf = onlyIf(Dummy, callback);
+      shallow(<DummyOnlyIf />, { context });
+      assert(callback.calledWith({}, null, context));
+    });
+
+    it('renders the component if the condition is true', () => {
+      const DummyOnlyIf = onlyIf(Dummy, () => true);
+      const wrapper = shallow(<DummyOnlyIf />);
+      assert(wrapper.containsMatchingElement(Dummy));
+    });
+
+    it('renders the placeholder if the condition is false', () => {
+      const DummyOnlyIf = onlyIf(Dummy, () => false, Placeholder);
+      const wrapper = shallow(<DummyOnlyIf />);
+      assert(wrapper.contains(<Placeholder />));
+    });
+
+    it('renders null if the placeholder does not exist', () => {
+      const DummyOnlyIf = onlyIf(Dummy, () => false);
+      const wrapper = shallow(<DummyOnlyIf />);
+      assert.equal(wrapper.type(), null);
+    });
   });
 
-  it('calls the condition function with the state', () => {
-    const callback = sinon.spy();
-    const state = { test: true };
-    const DummyOnlyIf = onlyIf(Dummy, callback);
-    const wrapper = shallow(<DummyOnlyIf />);
-    wrapper.setState(state);
-    assert(callback.calledWith({}, state));
-  });
+  context('stateless components', () => {
+    it('calls the condition function with the props', () => {
+      const callback = sinon.spy();
+      const props = { test: true };
+      const DummyOnlyIf = onlyIf(StatelessDummy, callback);
+      shallow(<DummyOnlyIf {...props} />);
+      assert(callback.calledWith(props));
+    });
 
-  it('calls the condition function with the context', () => {
-    const callback = sinon.spy();
-    const context = { test: true };
-    const DummyOnlyIf = onlyIf(Dummy, callback);
-    shallow(<DummyOnlyIf />, { context });
-    assert(callback.calledWith({}, null, context));
-  });
+    it('calls the condition function with the context', () => {
+      const callback = sinon.spy();
+      const context = { test: true };
+      const DummyOnlyIf = onlyIf(StatelessDummy, callback);
+      shallow(<DummyOnlyIf />, { context });
+      assert(callback.calledOnce);
+      assert(callback.calledWith({}, context));
+    });
 
-  it('renders the component if the condition is true', () => {
-    const DummyOnlyIf = onlyIf(Dummy, () => true);
-    const wrapper = shallow(<DummyOnlyIf />);
-    assert(wrapper.containsMatchingElement(Dummy));
-  });
+    it('renders the component if the condition is true', () => {
+      const DummyOnlyIf = onlyIf(StatelessDummy, () => true);
+      const wrapper = shallow(<DummyOnlyIf />);
+      assert(wrapper.contains(<StatelessDummy />));
+    });
 
-  it('renders the placeholder if the condition is false', () => {
-    const DummyOnlyIf = onlyIf(Dummy, () => false, Placeholder);
-    const wrapper = shallow(<DummyOnlyIf />);
-    assert(wrapper.contains(<Placeholder />));
-  });
+    it('renders the placeholder if the condition is false', () => {
+      const DummyOnlyIf = onlyIf(StatelessDummy, () => false, Placeholder);
+      const wrapper = shallow(<DummyOnlyIf />);
+      assert(wrapper.contains(<Placeholder />));
+    });
 
-  it('renders null if the placeholder does not exist', () => {
-    const DummyOnlyIf = onlyIf(Dummy, () => false);
-    const wrapper = shallow(<DummyOnlyIf />);
-    assert.equal(wrapper.type(), null);
+    it('renders null if the placeholder does not exist', () => {
+      const DummyOnlyIf = onlyIf(StatelessDummy, () => false);
+      const wrapper = shallow(<DummyOnlyIf />);
+      assert.equal(wrapper.type(), null);
+    });
   });
 });


### PR DESCRIPTION
As opposed to the README I noticed that the higher order component will only work with stateful components due to the fact that it uses `extends` to create the returned component. This can be easily reproduced by replacing `<Dummy />` in the test with the following version:

``` jsx
const Dummy = () => <div>Dummy</div>;
Dummy.contextTypes = {
  test: React.PropTypes.bool,
};
```

which makes all tests fail.

This PR checks if the passed component is stateful or not and proceeds accordingly.
